### PR TITLE
Add "--empty" flag to create empty repositories

### DIFF
--- a/src/github_rest_cli/api.py
+++ b/src/github_rest_cli/api.py
@@ -70,15 +70,18 @@ def get_repository(name: str, org: str = None):
     return None
 
 
-def create_repository(name: str, visibility: str, org: str = None):
+def create_repository(name: str, visibility: str, org: str = None, empty: bool = False):
     data = {
         "name": name,
-        "auto_init": "true",
         "visibility": visibility,
+        "auto_init": True,
     }
 
     if visibility == "private":
         data["private"] = True
+
+    if empty:
+        data["auto_init"] = False
 
     owner = fetch_user()
     headers = get_headers()

--- a/src/github_rest_cli/main.py
+++ b/src/github_rest_cli/main.py
@@ -103,6 +103,14 @@ def cli():
         dest="org",
         help="The organization name",
     )
+    create_repo_parser.add_argument(
+        "-e",
+        "--empty",
+        required=False,
+        action="store_true",
+        dest="empty",
+        help="Create an empty repository",
+    )
     create_repo_parser.set_defaults(func=create_repository)
 
     # Subparser for "delete-repository" function
@@ -197,7 +205,7 @@ def cli():
         elif command == "list-repo":
             args.func(args.page, args.sort, args.role)
         elif command == "create-repo":
-            args.func(args.name, args.visibility, args.org)
+            args.func(args.name, args.visibility, args.org, args.empty)
         elif command == "delete-repo":
             args.func(args.name, args.org)
         elif command == "dependabot":


### PR DESCRIPTION
This PR addresses issue #52.

It introduces the **--empty** flag to the **create-repo** command, allowing users to create repositories without auto-initialized files (e.g., README). When this flag is used, the repository will be created empty.

Changes:
- Added `--empty` flag to the `create-repo` CLI command
- Skips auto_init when the flag is set